### PR TITLE
Connect menu with cart placeholder logic

### DIFF
--- a/frontend/static/js/cart.js
+++ b/frontend/static/js/cart.js
@@ -1,0 +1,22 @@
+// frontend/static/js/cart.js
+
+/**
+ * Temporary placeholder for cart logic.
+ * Right now it just logs to the console so we can see it's wired correctly later.
+ */
+let cart = [];
+
+function loadCartFromStorage() { /* */ }
+
+function saveCartToStorage() { /* */ }
+
+export function addToCart(item) {
+    console.log("addToCart() from cart.js called with item:", item);
+    saveCartToStorage();
+    alert(`Added "${item.name}" to cart (total items: ${cart.length})`);
+}
+
+export function initCartUI() {
+  loadCartFromStorage();
+  console.log("Cart initialized on menu page:", cart);
+}

--- a/frontend/static/js/components/menuCard.js
+++ b/frontend/static/js/components/menuCard.js
@@ -13,6 +13,7 @@
  * @param {number} item.price
  * @returns {HTMLElement} A DOM node representing the card.
  */
+import {addToCart} from "../cart.js"
 export function createMenuCard(item) {
   // Create the root container for the card: <div class="menu-card">
   const el = document.createElement('div');
@@ -80,16 +81,11 @@ export function createMenuCard(item) {
   const btnAdd = el.querySelector('.btn-add');
   // Guard in case markup changes and the selector fails.
   if (btnAdd) {
-    btnAdd.addEventListener('click', () => {
-      // FIX: Added fallback to item._id in case item.id is missing
-      // ISSUE: Some items might have _id instead of id field
-      const itemId = item.id || item._id;
-      if (itemId) {
-        window.location.href=`/cart?item=${encodeURIComponent(itemId)}`
-      } else {
-        // DEBUG: Log error if both id and _id are missing
-        console.error('Item ID is missing', item);
-      }
+    btnAdd.addEventListener('click', (e) => {
+      e.stopPropagation();
+      addToCart(item)
+      
+    console.log("Add button clicked for:", item);
     })
   }
 

--- a/frontend/static/js/menu.js
+++ b/frontend/static/js/menu.js
@@ -11,7 +11,7 @@ import { renderItemDetail } from './ui/menuRenderer.js';
 // FIX: Changed from './components/Modal.js' (incorrect capitalization) to './components/modal.js'
 // ISSUE: Module import was failing because filename is lowercase 'modal.js' not 'Modal.js'
 import { createModal } from './components/modal.js';
-
+import { initCartUI } from "./cart.js";
 /**
  * Load the menu list into the #menuList container.
  * 
@@ -103,6 +103,7 @@ async function showDetail(id) {
  */
 document.addEventListener("DOMContentLoaded", () => {
   loadMenu();
+  initCartUI();
 
   const menuListEl = document.getElementById('menuList');
   if (menuListEl) {


### PR DESCRIPTION
This pull request introduces the initial integration of cart functionality into the frontend. The main focus is on wiring up the cart logic and connecting it to the menu UI, laying the groundwork for future enhancements. The changes include adding a new `cart.js` module, updating the menu card component to use the new cart logic, and initializing the cart when the menu page loads.

**Cart functionality integration:**

* Added a new `frontend/static/js/cart.js` module with placeholder cart logic, including functions to add items to the cart and initialize the cart UI.
* Updated `frontend/static/js/components/menuCard.js` to import and use the `addToCart` function, replacing the previous redirect-based add-to-cart behavior with a direct call to the cart logic. [[1]](diffhunk://#diff-f88974b540d1125892752b473bdaeb1f99d70105133a70b946fa1299c2aef072R16) [[2]](diffhunk://#diff-f88974b540d1125892752b473bdaeb1f99d70105133a70b946fa1299c2aef072L83-R88)

**Menu page initialization:**

* Imported and called `initCartUI` from `cart.js` in `frontend/static/js/menu.js` to ensure the cart is initialized when the menu page loads. [[1]](diffhunk://#diff-eff2315c1e5e5ba2496faf8f06d7ab5b72e48df66d3b2019599a3f26f2707347L14-R14) [[2]](diffhunk://#diff-eff2315c1e5e5ba2496faf8f06d7ab5b72e48df66d3b2019599a3f26f2707347R106)