### PR TITLE
Change checkout URL to '/checkout'

### DIFF
--- a/frontend/templates/cart.html
+++ b/frontend/templates/cart.html
@@ -117,7 +117,7 @@ Flamehouse{% endblock %} {% block styles %}
 
         // Checkout button: redirect to Flask /checkout route
         checkoutButton.addEventListener("click", function () {
-            window.location.href = "/revontulet/checkout";
+            window.location.href = "/checkout";
         });
     });
 


### PR DESCRIPTION
This pull request makes a minor update to the checkout button in the shopping cart template, correcting the redirect path to the checkout route. 

* Changed the checkout button's redirect URL from `/revontulet/checkout` to `/checkout` in `cart.html` to ensure proper navigation.