### PR TITLE
Update admin sidebar links to remove 'revontulet'

### DIFF
--- a/frontend/templates/admin_sidebar.html
+++ b/frontend/templates/admin_sidebar.html
@@ -5,25 +5,25 @@
         <!-- Sidebar buttons for admin management pages -->
         <button
             class="filter-btn"
-            onclick="window.location.href='/revontulet/admin-menu'"
+            onclick="window.location.href='/admin-menu'"
         >
             {{ t.manage_menu }}
         </button>
         <button
             class="filter-btn"
-            onclick="window.location.href='/revontulet/admin-reservations'"
+            onclick="window.location.href='/admin-reservations'"
         >
             {{ t.manage_reservations }}
         </button>
         <button
             class="filter-btn"
-            onclick="window.location.href='/revontulet/admin-orders'"
+            onclick="window.location.href='/admin-orders'"
         >
             {{ t.manage_orders }}
         </button>
         <button
             class="filter-btn"
-            onclick="window.location.href='/revontulet/admin-users'"
+            onclick="window.location.href='/admin-users'"
         >
             {{ t.manage_users }}
         </button>


### PR DESCRIPTION
This pull request updates the admin sidebar navigation links to use simplified URLs, removing the `/revontulet` prefix from all admin management page buttons.

Navigation updates:

* Updated the `onclick` handlers for the admin sidebar buttons in `admin_sidebar.html` to use `/admin-menu`, `/admin-reservations`, `/admin-orders`, and `/admin-users` instead of their previous `/revontulet/`-prefixed paths.